### PR TITLE
Remove the hash associated to the commits in GitGraph

### DIFF
--- a/frontend/src/components/GitGraph.js
+++ b/frontend/src/components/GitGraph.js
@@ -21,7 +21,7 @@ function GitGraph (props) {
                 },
                 message: {
                     displayAuthor: false,
-                    displayHash: true,
+                    displayHash: false,
                     font: "normal 13pt Arial"
                 }
             }


### PR DESCRIPTION
Remove the hash associated to the commits in GitGraph